### PR TITLE
Fix insertion sort

### DIFF
--- a/workspace/src/InsertionSort.java
+++ b/workspace/src/InsertionSort.java
@@ -7,7 +7,7 @@ public class InsertionSort {
 			int temp = x[i];
 			int j;
 			for (j = i-1; j >= 0; j--) {
-				if (x[j] > x[i])
+				if (x[j] > temp)
 					x[j+1] = x[j];
 				else {
 					break;


### PR DESCRIPTION
it was just a matter of changing the comparison inside of the inner loop.

Before, by the second iteration, the x[i] was always the number previously swapped.
